### PR TITLE
Fix typo

### DIFF
--- a/index.pug
+++ b/index.pug
@@ -183,7 +183,7 @@ html
         #e.section
           .section-header
             .title Experience & Education
-            .seperator
+            .separator
           #e-container
             .e-head
               .e-title Soracom (Software Engineering Intern)


### PR DESCRIPTION
Problem: For the separator blocks, the author wrote "seperator" instead of "separator." This is clearly wrong and misleading to employers.

Fix: `:,s/seperator/separator/g`